### PR TITLE
Memory is purged each time new data wants to be represented

### DIFF
--- a/angular-tag-cloud-module/src/app/tag-cloud-module/tag-cloud.component.ts
+++ b/angular-tag-cloud-module/src/app/tag-cloud-module/tag-cloud.component.ts
@@ -49,6 +49,8 @@ export class TagCloudComponent implements OnChanges, AfterContentInit, AfterCont
 
   ngOnChanges(changes: SimpleChanges) {
     this.dataChanges.emit(changes);
+    this.alreadyPlacedWords = [];
+
 
     // check if data is not null or empty
     if (!this.data) {


### PR DESCRIPTION
#28 This PR fixes issue where lag was intruduced due to several data changes in the cloud. There is no point in saving in memory old representations of the tags.