### PR TITLE
https://github.com/d-koppenhagen/angular-tag-cloud-module/issues/36

### DIFF
--- a/angular-tag-cloud-module/src/app/tag-cloud-module/tag-cloud.component.ts
+++ b/angular-tag-cloud-module/src/app/tag-cloud-module/tag-cloud.component.ts
@@ -78,10 +78,6 @@ export class TagCloudComponent implements OnChanges, AfterContentInit, AfterCont
       console.error('angular-tag-cloud: No data passed. Please pass an Array of CloudData');
       return;
     }
-    if (this.data.length === 0) {
-      console.log('angular-tag-cloud: Empty dataset');
-      return;
-    }
 
     // values changed, reset cloud
     this.el.nativeElement.innerHTML = '';


### PR DESCRIPTION
Removed check for empty data array that would exit out of drawing tag cloud. Problematic as it could leave stale data rendered even though it no longer existed.