### PR TITLE
remove colorStyle only when zoomOnHover.color is set.

### DIFF
--- a/projects/angular-tag-cloud-module/src/lib/tag-cloud.component.ts
+++ b/projects/angular-tag-cloud-module/src/lib/tag-cloud.component.ts
@@ -350,9 +350,11 @@ export class TagCloudComponent implements OnChanges, AfterContentInit, AfterCont
 
       wordSpan.onmouseout = () => {
         this.r2.setStyle(wordSpan, 'transform', `none ${transformString}`);
-        word.link
-          ? this.r2.removeStyle(node, 'color')
-          : this.r2.removeStyle(wordSpan, 'color');
+        if (this.options.zoomOnHover.color) {
+          word.link
+            ? this.r2.removeStyle(node, 'color')
+            : this.r2.removeStyle(wordSpan, 'color');
+        }
       };
     }
 


### PR DESCRIPTION
(fixes bug where a custom color is set on elements, which is removed aver hovering over the item)