### PR TITLE
#51 fix bug - Tooltips are displayed behind other words

### DIFF
--- a/projects/angular-tag-cloud-module/src/lib/tag-cloud.component.ts
+++ b/projects/angular-tag-cloud-module/src/lib/tag-cloud.component.ts
@@ -487,6 +487,16 @@ export class TagCloudComponent implements OnChanges, AfterContentInit, AfterCont
       this.clicked.emit(word);
     };
 
+    // Put the word (and its tooltip) in foreground when cursor is above
+    wordSpan.onmouseenter = () => {
+      wordSpan.style.zIndex = "2";
+    };
+
+    // Otherwise, restore standard priority
+    wordSpan.onmouseleave = () => {
+      wordSpan.style.zIndex = "1";
+    };
+
     // append word text
     let node = this.r2.createText(word.text);
 

--- a/src/app/helpers.ts
+++ b/src/app/helpers.ts
@@ -45,7 +45,7 @@ export function randomData(cnt?: number, rotate?: boolean): CloudData[] {
       link,
       external,
       rotate: r,
-      // tooltip: 'tooltip'
+      tooltip: 'tooltip ' + text
     };
 
     cd.push(el);


### PR DESCRIPTION
The tooltip depth in the stacking context  was linked to its corresponding word. So, from a stacking context point of view, if a word was behind another, its tooltip would also be behind.

- fixed: when the tooltip is displayed, the z-index of the word is increased. When the tooltip is hidden, the z-index is decreased.

- added tooltip option in helper.ts, in order to check the correction.
