### PR TITLE
fix: do not run into infinte loop

### DIFF
--- a/projects/angular-tag-cloud-module/src/lib/tag-cloud.component.ts
+++ b/projects/angular-tag-cloud-module/src/lib/tag-cloud.component.ts
@@ -521,6 +521,8 @@ export class TagCloudComponent
         while (
           this.options.width &&
           this.options.height &&
+          wordSpan.offsetHeight &&
+          wordSpan.offsetWidth &&
           this.hitTest(wordSpan)
         ) {
           radius += this.options.step;


### PR DESCRIPTION
... when the wordcloud is hidden (e.g. with display: none)

closes #45