### PR TITLE
Update README.md about enabling custom css

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,11 @@ export class AppComponent {
 
 ## Using a custom Stylesheet
 You can adjust the style for the component. Please read the [Wiki article](https://github.com/d-koppenhagen/angular-tag-cloud-module/wiki/Custom-CSS-Style) and follow the instructions.
+
+Note that you have to set the class.custom-css attribute to true in order for the custom css to be applied, e.g. :
+```html
+<angular-tag-cloud [config]="options" [data]="data"></angular-tag-cloud>
+```
 ![TagCloud with custom stylesheet][logo2]
 
 ## Place data on fixed positions

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ You can adjust the style for the component. Please read the [Wiki article](https
 
 Note that you have to set the class.custom-css attribute to true in order for the custom css to be applied, e.g. :
 ```html
-<angular-tag-cloud [config]="options" [data]="data"></angular-tag-cloud>
+<angular-tag-cloud [config]="options" [data]="data" [class.custom-css]='true'></angular-tag-cloud>
 ```
 ![TagCloud with custom stylesheet][logo2]
 

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ export class AppComponent {
 ## Using a custom Stylesheet
 You can adjust the style for the component. Please read the [Wiki article](https://github.com/d-koppenhagen/angular-tag-cloud-module/wiki/Custom-CSS-Style) and follow the instructions.
 
-Note that you have to set the class.custom-css attribute to true in order for the custom css to be applied, e.g. :
+Note that you have to set the class attribute in order for the custom css class to be applied, e.g. :
 ```html
 <angular-tag-cloud [config]="options" [data]="data" [class.custom-css]='true'></angular-tag-cloud>
 ```


### PR DESCRIPTION
Update README.md about enabling custom css that you have to set the class.custom-css attribute to true in order for the custom css to be applied because it was unclear.